### PR TITLE
Fix spelling errors

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -792,7 +792,7 @@ msgid "Already in your watchlist"
 msgstr "Ya está en su lista"
 
 #: src/widgets/search_result_row.py:170
-msgid "Already in your whatchlist"
+msgid "Already in your watchlist"
 msgstr "Ya está en su lista"
 
 #: src/widgets/season_expander.py:141

--- a/po/es.po
+++ b/po/es.po
@@ -554,7 +554,7 @@ msgstr "Modo sin conexión"
 #: src/ui/preferences.blp:36
 msgctxt "preferences"
 msgid ""
-"Ticket Booth can work entirelly offline. If you choose to run in this mode, "
+"Ticket Booth can work entirely offline. If you choose to run in this mode, "
 "some features that require the Internet and/or access to third party APIs "
 "will not be available."
 msgstr ""
@@ -783,15 +783,12 @@ msgstr "Actualización automática"
 
 #: src/widgets/episode_row.py:242
 msgctxt "message dialog body"
-msgid "All cheanges to this episode will be lost."
+msgid "All changes to this episode will be lost."
 msgstr "Todos los cambios de este episodio se perderán."
 
 #: src/widgets/search_result_row.py:97
-#, fuzzy
-msgid "Already in your watchlist"
-msgstr "Ya está en su lista"
-
 #: src/widgets/search_result_row.py:170
+#, fuzzy
 msgid "Already in your watchlist"
 msgstr "Ya está en su lista"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -536,7 +536,7 @@ msgstr ""
 #: src/ui/preferences.blp:36
 msgctxt "preferences"
 msgid ""
-"Ticket Booth can work entirelly offline. If you choose to run in this mode, "
+"Ticket Booth can work entirely offline. If you choose to run in this mode, "
 "some features that require the Internet and/or access to third party APIs "
 "will not be available."
 msgstr ""
@@ -750,13 +750,10 @@ msgstr ""
 
 #: src/widgets/episode_row.py:242
 msgctxt "message dialog body"
-msgid "All cheanges to this episode will be lost."
+msgid "All changes to this episode will be lost."
 msgstr ""
 
 #: src/widgets/search_result_row.py:97
-msgid "Already in your watchlist"
-msgstr ""
-
 #: src/widgets/search_result_row.py:170
 msgid "Already in your watchlist"
 msgstr ""

--- a/po/eu.po
+++ b/po/eu.po
@@ -758,7 +758,7 @@ msgid "Already in your watchlist"
 msgstr ""
 
 #: src/widgets/search_result_row.py:170
-msgid "Already in your whatchlist"
+msgid "Already in your watchlist"
 msgstr ""
 
 #: src/widgets/season_expander.py:141

--- a/po/fr.po
+++ b/po/fr.po
@@ -797,7 +797,7 @@ msgid "Already in your watchlist"
 msgstr "Déjà dans votre liste de visionnage"
 
 #: src/widgets/search_result_row.py:170
-msgid "Already in your whatchlist"
+msgid "Already in your watchlist"
 msgstr "Déjà dans votre liste de visionnage"
 
 #: src/widgets/season_expander.py:141

--- a/po/fr.po
+++ b/po/fr.po
@@ -558,7 +558,7 @@ msgstr "Mode hors-ligne"
 #: src/ui/preferences.blp:36
 msgctxt "preferences"
 msgid ""
-"Ticket Booth can work entirelly offline. If you choose to run in this mode, "
+"Ticket Booth can work entirely offline. If you choose to run in this mode, "
 "some features that require the Internet and/or access to third party APIs "
 "will not be available."
 msgstr ""
@@ -788,15 +788,12 @@ msgstr "Mise à jour automatique"
 
 #: src/widgets/episode_row.py:242
 msgctxt "message dialog body"
-msgid "All cheanges to this episode will be lost."
+msgid "All changes to this episode will be lost."
 msgstr "Tous les changements appliqués à cet épisode seront perdus."
 
 #: src/widgets/search_result_row.py:97
-#, fuzzy
-msgid "Already in your watchlist"
-msgstr "Déjà dans votre liste de visionnage"
-
 #: src/widgets/search_result_row.py:170
+#, fuzzy
 msgid "Already in your watchlist"
 msgstr "Déjà dans votre liste de visionnage"
 

--- a/po/it.po
+++ b/po/it.po
@@ -792,7 +792,7 @@ msgid "Already in your watchlist"
 msgstr "Già nella tua lista"
 
 #: src/widgets/search_result_row.py:170
-msgid "Already in your whatchlist"
+msgid "Already in your watchlist"
 msgstr "Già nella tua lista"
 
 #: src/widgets/season_expander.py:141

--- a/po/it.po
+++ b/po/it.po
@@ -555,7 +555,7 @@ msgstr "Modalità offline"
 #: src/ui/preferences.blp:36
 msgctxt "preferences"
 msgid ""
-"Ticket Booth can work entirelly offline. If you choose to run in this mode, "
+"Ticket Booth can work entirely offline. If you choose to run in this mode, "
 "some features that require the Internet and/or access to third party APIs "
 "will not be available."
 msgstr ""
@@ -783,15 +783,12 @@ msgstr "Aggiornamento automatico"
 
 #: src/widgets/episode_row.py:242
 msgctxt "message dialog body"
-msgid "All cheanges to this episode will be lost."
+msgid "All changes to this episode will be lost."
 msgstr "Tutte le modifiche a questo episodio andranno perse."
 
 #: src/widgets/search_result_row.py:97
-#, fuzzy
-msgid "Already in your watchlist"
-msgstr "Già nella tua lista"
-
 #: src/widgets/search_result_row.py:170
+#, fuzzy
 msgid "Already in your watchlist"
 msgstr "Già nella tua lista"
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -542,7 +542,7 @@ msgstr "Frakoblet modus"
 #: src/ui/preferences.blp:36
 msgctxt "preferences"
 msgid ""
-"Ticket Booth can work entirelly offline. If you choose to run in this mode, "
+"Ticket Booth can work entirely offline. If you choose to run in this mode, "
 "some features that require the Internet and/or access to third party APIs "
 "will not be available."
 msgstr ""
@@ -758,15 +758,12 @@ msgstr ""
 
 #: src/widgets/episode_row.py:242
 msgctxt "message dialog body"
-msgid "All cheanges to this episode will be lost."
+msgid "All changes to this episode will be lost."
 msgstr "Alle endringer av denne episoden vil gå tapt."
 
 #: src/widgets/search_result_row.py:97
-#, fuzzy
-msgid "Already in your watchlist"
-msgstr "Allerede i din oppsynsliste"
-
 #: src/widgets/search_result_row.py:170
+#, fuzzy
 msgid "Already in your watchlist"
 msgstr "Allerede i din oppsynsliste"
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -767,7 +767,7 @@ msgid "Already in your watchlist"
 msgstr "Allerede i din oppsynsliste"
 
 #: src/widgets/search_result_row.py:170
-msgid "Already in your whatchlist"
+msgid "Already in your watchlist"
 msgstr "Allerede i din oppsynsliste"
 
 #: src/widgets/season_expander.py:141

--- a/po/ticketbooth.pot
+++ b/po/ticketbooth.pot
@@ -536,7 +536,7 @@ msgstr ""
 #: src/ui/preferences.blp:36
 msgctxt "preferences"
 msgid ""
-"Ticket Booth can work entirelly offline. If you choose to run in this mode, "
+"Ticket Booth can work entirely offline. If you choose to run in this mode, "
 "some features that require the Internet and/or access to third party APIs "
 "will not be available."
 msgstr ""
@@ -750,13 +750,10 @@ msgstr ""
 
 #: src/widgets/episode_row.py:242
 msgctxt "message dialog body"
-msgid "All cheanges to this episode will be lost."
+msgid "All changes to this episode will be lost."
 msgstr ""
 
 #: src/widgets/search_result_row.py:97
-msgid "Already in your watchlist"
-msgstr ""
-
 #: src/widgets/search_result_row.py:170
 msgid "Already in your watchlist"
 msgstr ""

--- a/po/ticketbooth.pot
+++ b/po/ticketbooth.pot
@@ -758,7 +758,7 @@ msgid "Already in your watchlist"
 msgstr ""
 
 #: src/widgets/search_result_row.py:170
-msgid "Already in your whatchlist"
+msgid "Already in your watchlist"
 msgstr ""
 
 #: src/widgets/season_expander.py:141

--- a/src/dialogs/add_manual_dialog.py
+++ b/src/dialogs/add_manual_dialog.py
@@ -28,7 +28,7 @@ from ..widgets.season_expander import SeasonExpander
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/dialogs/add_manual.ui')
 class AddManualDialog(Adw.Window):
     """
-    This class rappresents the window to manually add content to the db.
+    This class represents the window to manually add content to the db.
 
     Properties:
         edit_mode (bool): whether or not the window is in add/edit mode
@@ -157,7 +157,7 @@ class AddManualDialog(Adw.Window):
             seasons_as_model(List[SeasonModel]): a list of SeasonModels
 
         Returns:
-            a list of tuples rappresenting the same data
+            a list of tuples representing the same data
         """
 
         seasons_as_tuple = []
@@ -576,7 +576,7 @@ class AddManualDialog(Adw.Window):
         Args:
             title (str): a title
             uri (str): an uri
-            episodes (List[tuple]): a list of tuples rappresenting episodes
+            episodes (List[tuple]): a list of tuples representing episodes
 
         Returns:
             tuple matching the passed data

--- a/src/dialogs/add_tmdb_dialog.py
+++ b/src/dialogs/add_tmdb_dialog.py
@@ -12,7 +12,7 @@ from ..providers.tmdb_provider import TMDBProvider
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/dialogs/add_tmdb.ui')
 class AddTMDBDialog(Adw.Window):
     """
-    This class rappresents the window used to search for movies and tv-series on TMDB.
+    This class represents the window used to search for movies and tv-series on TMDB.
 
     Properties:
         None

--- a/src/dialogs/edit_season_dialog.py
+++ b/src/dialogs/edit_season_dialog.py
@@ -15,7 +15,7 @@ from ..widgets.episode_row import EpisodeRow
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/dialogs/edit_season.ui')
 class EditSeasonDialog(Adw.Window):
     """
-    This class rappresents the window to edit a season.
+    This class represents the window to edit a season.
 
     Properties:
         None

--- a/src/models/episode_model.py
+++ b/src/models/episode_model.py
@@ -15,7 +15,7 @@ from .. import shared  # type: ignore
 
 class EpisodeModel(GObject.GObject):
     """
-    This class rappresents an episode object stored in the db.
+    This class represents an episode object stored in the db.
 
     Properties:
         id (str): episode id
@@ -26,7 +26,7 @@ class EpisodeModel(GObject.GObject):
         show_id (int): id of the show the episode belongs to
         still_path (str): uri of the episode still
         title (str): episode title
-        watched (bool): wheater the episode has been watched or not
+        watched (bool): whether the episode has been watched or not
 
     Methods:
         None

--- a/src/models/language_model.py
+++ b/src/models/language_model.py
@@ -9,7 +9,7 @@ from gi.repository import GObject
 
 class LanguageModel(GObject.GObject):
     """
-    This class rappresents a language object stored in the db.
+    This class represents a language object stored in the db.
 
     Properties:
         iso_name (str): ISO_639_1 code

--- a/src/models/movie_model.py
+++ b/src/models/movie_model.py
@@ -19,7 +19,7 @@ from ..models.language_model import LanguageModel
 
 class MovieModel(GObject.GObject):
     """
-    This class rappresents a movie object stored in the db.
+    This class represents a movie object stored in the db.
 
     Properties:
         add_date (str): date of addition to the db (ISO format)

--- a/src/models/search_result_model.py
+++ b/src/models/search_result_model.py
@@ -9,7 +9,7 @@ from gi.repository import GObject
 
 class SearchResultModel(GObject.GObject):
     """
-    This class rappresents the object returned from the TMDB search endpoint.
+    This class represents the object returned from the TMDB search endpoint.
 
     Properties:
         title (str): content's title

--- a/src/models/season_model.py
+++ b/src/models/season_model.py
@@ -19,7 +19,7 @@ from ..models.episode_model import EpisodeModel
 
 class SeasonModel(GObject.GObject):
     """
-    This class rappresents a season object stored in the db.
+    This class represents a season object stored in the db.
 
     Properties:
         episodes (List[EpisodeModel]): list of episodes in self

--- a/src/models/series_model.py
+++ b/src/models/series_model.py
@@ -20,7 +20,7 @@ from ..models.season_model import SeasonModel
 
 class SeriesModel(GObject.GObject):
     """
-    This class rappresents a series object stored in the db.
+    This class represents a series object stored in the db.
 
     Properties:
         add_date (str): date of addition to the db (ISO format)
@@ -29,7 +29,7 @@ class SeriesModel(GObject.GObject):
         episodes_number (int): number of total episodes
         genres (List[str]): list of genres
         id (str): series id
-        in_production (bool): wheater the series is still in production
+        in_production (bool): whether the series is still in production
         manual (bool): if the series is added manually
         original_language (LanguageModel): LanguageModel of the original language
         original_title (str): series title in original language
@@ -41,7 +41,7 @@ class SeriesModel(GObject.GObject):
         status (str): series status
         tagline (str): series tagline
         title (str): series title
-        watched (bool): wheater the series has been whatched completelly or not
+        watched (bool): whether the series has been watched completely or not
 
     Methods:
         None

--- a/src/pages/edit_episode_page.py
+++ b/src/pages/edit_episode_page.py
@@ -11,7 +11,7 @@ from ..models.episode_model import EpisodeModel
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/pages/edit_episode_page.ui')
 class EditEpisodeNavigationPage(Adw.NavigationPage):
     """
-    This class rappresents the 'edit episode' NavigationPane.
+    This class represents the 'edit episode' NavigationPane.
 
     Properties:
         None

--- a/src/ui/preferences.blp
+++ b/src/ui/preferences.blp
@@ -33,7 +33,7 @@ template $PreferencesWindow: Adw.PreferencesWindow {
 
     Adw.PreferencesGroup _offline_group {
       title: C_("preferences", "Offline Mode");
-      description: C_("preferences", "Ticket Booth can work entirelly offline. If you choose to run in this mode, some features that require the Internet and/or access to third party APIs will not be available.");
+      description: C_("preferences", "Ticket Booth can work entirely offline. If you choose to run in this mode, some features that require the Internet and/or access to third party APIs will not be available.");
 
       Adw.SwitchRow _offline_switch {
         title: C_("preferences", "Enable Offline Mode");

--- a/src/views/content_view.py
+++ b/src/views/content_view.py
@@ -16,7 +16,7 @@ from ..widgets.poster_button import PosterButton
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/views/content_view.ui')
 class ContentView(Adw.Bin):
     """
-    This class rappresents the movies view of the app.
+    This class represents the movies view of the app.
 
     Properties:
         None

--- a/src/views/first_run_view.py
+++ b/src/views/first_run_view.py
@@ -17,7 +17,7 @@ from ..providers.tmdb_provider import TMDBProvider as tmdb
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/views/first_run_view.ui')
 class FirstRunView(Adw.Bin):
     """
-    This class rappresents the initial setup the app needs to offer full fuctionality.
+    This class represents the initial setup the app needs to offer full fuctionality.
 
     Properties:
         None

--- a/src/views/main_view.py
+++ b/src/views/main_view.py
@@ -21,7 +21,7 @@ from ..widgets.theme_switcher import ThemeSwitcher
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/views/main_view.ui')
 class MainView(Adw.Bin):
     """
-    This class rappresents the main view of the app.
+    This class represents the main view of the app.
 
     Properties:
         None

--- a/src/widgets/background_activity_row.py
+++ b/src/widgets/background_activity_row.py
@@ -10,7 +10,7 @@ from .. import shared  # type: ignore
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/widgets/background_activity_row.ui')
 class BackgroundActivityRow(Adw.Bin):
     """
-    This class rappresents a row in the BackgroundIndicator popover.
+    This class represents a row in the BackgroundIndicator popover.
 
     Properties:
         title (str): a title

--- a/src/widgets/background_indicator.py
+++ b/src/widgets/background_indicator.py
@@ -11,7 +11,7 @@ from ..background_queue import BackgroundQueue
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/widgets/background_indicator.ui')
 class BackgroundIndicator(Adw.Bin):
     """
-    This class rappresents the indicator for background activities.
+    This class represents the indicator for background activities.
 
     Properties:
         queue (Gio.ListStore): the queue

--- a/src/widgets/episode_row.py
+++ b/src/widgets/episode_row.py
@@ -239,7 +239,7 @@ class EpisodeRow(Adw.PreferencesRow):
         dialog = Adw.MessageDialog.new(self.get_ancestor(Adw.Window),
                                        C_('message dialog heading', 'Delete {title}?').format(
                                            title=f'{self.episode_number}.{self.title}'),
-                                       C_('message dialog body', 'All cheanges to this episode will be lost.')
+                                       C_('message dialog body', 'All changes to this episode will be lost.')
                                        )
         dialog.add_response('cancel', C_('message dialog action', '_Cancel'))
         dialog.add_response('delete', C_('message dialog action', '_Delete'))

--- a/src/widgets/image_selector.py
+++ b/src/widgets/image_selector.py
@@ -10,7 +10,7 @@ from .. import shared  # type: ignore
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/widgets/image_selector.ui')
 class ImageSelector(Adw.Bin):
     """
-    This class rappresents the image selector and previewer with options to open a file and, if one is already opened,
+    This class represents the image selector and previewer with options to open a file and, if one is already opened,
     to delete the selection.
 
     Properties:

--- a/src/widgets/search_result_row.py
+++ b/src/widgets/search_result_row.py
@@ -167,7 +167,7 @@ class SearchResultRow(Gtk.ListBoxRow):
         """
 
         local.add_content(id=self.tmdb_id, media_type=self.media_type)
-        self._add_btn.set_label(_('Already in your whatchlist'))
+        self._add_btn.set_label(_('Already in your watchlist'))
         self._add_btn.set_icon_name('check-plain')
         self._add_spinner.set_visible(False)
         self.get_ancestor(Adw.Window).get_transient_for(

--- a/src/widgets/season_expander.py
+++ b/src/widgets/season_expander.py
@@ -18,7 +18,7 @@ from ..widgets.episode_row import EpisodeRow
 @Gtk.Template(resource_path=shared.PREFIX + '/ui/widgets/season_expander.ui')
 class SeasonExpander(Adw.ExpanderRow):
     """
-    This class rappresents a season in the manual add window.
+    This class represents a season in the manual add window.
 
     Properties:
         season_title (str): season title


### PR DESCRIPTION
I fixed some spelling mistakes in English throughout the application such as translation files, preferences and models. 

I also consolidated some lines in the .po translations files, due to a spelling error needing to be translated in all .po files. For example, **watchlist** and **whatchlist** were both gettings translated even though whatchlist is a mistake.

```
#: src/widgets/search_result_row.py:97
#, fuzzy
msgid "Already in your watchlist"
msgstr "Ya está en su lista"

#: src/widgets/search_result_row.py:170
msgid "Already in your whatchlist"
msgstr "Ya está en su lista"
```

This could be reduced to

```
#: src/widgets/search_result_row.py:97
#: src/widgets/search_result_row.py:170
#, fuzzy
msgid "Already in your watchlist"
msgstr "Ya está en su lista"
```

The translation template ```ticketbooth.pot``` also needed to be updated to consolidate the spelling mistake translation.