### PR TITLE
Fix issue #23 - Don't overwrite watched status of local provider

### DIFF
--- a/src/providers/local_provider.py
+++ b/src/providers/local_provider.py
@@ -801,8 +801,7 @@ class LocalProvider:
                          runtime = ?,
                          status = ?,
                          tagline = ?,
-                         title = ?,
-                         watched = ?
+                         title = ?
                      WHERE id = ?;
                   """
             result = connection.cursor().execute(sql, (
@@ -821,7 +820,6 @@ class LocalProvider:
                 new.status,
                 new.tagline,
                 new.title,
-                new.watched,
                 old.id,
             ))
             connection.commit()


### PR DESCRIPTION
The watched status is never saved back to TMDB, so the local provider must keep its watched status when pulling updated metadata from TMDB.