### PR TITLE
Add link to TMDB Webpage

### DIFF
--- a/src/pages/details_page.py
+++ b/src/pages/details_page.py
@@ -412,6 +412,16 @@ class DetailsView(Adw.NavigationPage):
                        if self.content.in_production else _('No')))
             self._flow_box.append(box)
 
+        if self.content.id and self.content.manual == False:
+            box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+            label = Gtk.Label(label=_('TMDB ID'))
+            label.add_css_class('heading')
+            box.append(label)
+            url_str = '<a href="https://www.themoviedb.org/{category}/{id}" title="TMDB Webpage"> {id} </a>' \
+                .format(category = ("tv") if type(self.content) is SeriesModel else ("movie"), id = self.content.id)
+            box.append(Gtk.Label(label=url_str, use_markup = True))
+            self._flow_box.append(box)
+
         if self._flow_box.get_child_at_index(0) is None:
             self._additional_info_box.set_visible(False)
 


### PR DESCRIPTION
This adds a new section in the Additional Information Box that links to the page of the title in TMDB if the title was added from TMDB.
![grafik](https://github.com/aleiepure/ticketbooth/assets/12056468/84e281cd-1571-4c7e-9324-0aa1b238956a)
