### PR TITLE
Rework updates for series

### DIFF
--- a/src/pages/details_page.py
+++ b/src/pages/details_page.py
@@ -553,29 +553,9 @@ class DetailsView(Adw.NavigationPage):
             self.new_content = MovieModel(tmdb.get_movie(self.content.id))
             local.update_movie(old=self.content, new=self.new_content)
         else:
-
-            # Save episodes statuses before delete
-            wathced_episodes = []
-            for season in self.content.seasons:  # type: ignore
-                for episode in season.episodes:
-                    if episode.watched:
-                        wathced_episodes.append(episode.id)
-
-            local.delete_series(self.content.id)  # type: ignore
-
-            self.new_content = SeriesModel(
-                tmdb.get_serie(self.content.id))  # type: ignore
-
-            # Restore episodes statuses if they match before addition
-            for idx, season in enumerate(self.new_content.seasons):
-                for jdx, episode in enumerate(season.episodes):
-                    try:
-                        wathced_episodes.index(episode.id)
-                        self.new_content.seasons[idx].episodes[jdx].watched = True
-                    except ValueError:
-                        self.new_content.seasons[idx].episodes[jdx].watched = False
-
-            local.add_series(serie=self.new_content)
+            self.new_content = SeriesModel(tmdb.get_serie(self.content.id))
+            local.update_series(old=self.content, new=self.new_content)
+            
 
     def _on_update_done(self,
                         source: GObject.Object,

--- a/src/providers/local_provider.py
+++ b/src/providers/local_provider.py
@@ -862,6 +862,8 @@ class LocalProvider:
                 except ValueError:
                     new.seasons[idx].episodes[jdx].watched = False
 
+        new.add_date = old.add_date
+        
         LocalProvider.add_series(serie=new)
 
         return result.lastrowid

--- a/src/providers/local_provider.py
+++ b/src/providers/local_provider.py
@@ -785,7 +785,7 @@ class LocalProvider:
 
         with sqlite3.connect(shared.db) as connection:
             sql = """UPDATE movies
-                     SET add_date = ?,
+                     SET 
                          backdrop_path = ?,
                          budget = ?,
                          genres = ?,
@@ -803,7 +803,6 @@ class LocalProvider:
                      WHERE id = ?;
                   """
             result = connection.cursor().execute(sql, (
-                new.add_date,
                 new.backdrop_path,
                 new.budget,
                 ','.join(new.genres),
@@ -821,9 +820,9 @@ class LocalProvider:
                 old.id,
             ))
             connection.commit()
-            logging.debug(f'[db] Update movie {old.id}: {(new.add_date, new.backdrop_path, new.budget, ",".join(new.genres), new.manual, new.original_language.iso_name, new.original_title, new.overview, new.poster_path, new.release_date, new.revenue, new.runtime, new.status, new.tagline, new.title, old.id)}')
+            logging.debug(f'[db] Update movie {old.id}: {(new.backdrop_path, new.budget, ",".join(new.genres), new.manual, new.original_language.iso_name, new.original_title, new.overview, new.poster_path, new.release_date, new.revenue, new.runtime, new.status, new.tagline, new.title, old.id)}')
         return result.lastrowid
-
+    
     @staticmethod
     def mark_watched_episode(id: str, watched: bool) -> int | None:
         """

--- a/src/views/main_view.py
+++ b/src/views/main_view.py
@@ -185,9 +185,8 @@ class MainView(Adw.Bin):
         if series:
             for serie in series:    # type: ignore
                 if not serie.manual:
-                    local.delete_series(serie.id)
                     new_serie = SeriesModel(tmdb.get_serie(serie.id))
-                    local.add_series(serie=new_serie)
+                    local.update_series(old=serie,serie=new_serie)
 
     def _on_update_done(self,
                         source: GObject.Object,


### PR DESCRIPTION
This takes the automatic update logic puts it into the local provider and uses it for manual and automatic updates.
Before the automatic update would have deleted all watched information.
Also I have changed that the add date is not overwritten on any update in series or movies.